### PR TITLE
Fix NextAuth authorize syntax to build

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -21,6 +21,7 @@ export const authOptions = {
 
         if (user && await bcrypt.compare(credentials.password, user.password)) {
           return { id: String(user.id), username: user.username, name: user.username, email: user.username }
+        }
 
         return null
       },


### PR DESCRIPTION
## Summary
- close `authorize` callback `if` block for NextAuth credentials provider

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af05a0b470833087c72162105d187d